### PR TITLE
Fix module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/m-mizutani/trivew
+module github.com/m-mizutani/triview
 
 go 1.16
 


### PR DESCRIPTION
Fix module name (I think)

I've this error then I get your module:

```
$ go get github.com/m-mizutani/triview
go get: github.com/m-mizutani/triview@v0.0.0-20210504001219-86b9b051737e: parsing go.mod:
	module declares its path as: github.com/m-mizutani/trivew
	        but was required as: github.com/m-mizutani/triview
```